### PR TITLE
Configure Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+- '3.4'
+sudo: false
+install:
+- pip install -e git+https://github.com/deconst/preparer-sphinx.git#egg=deconstrst
+script:
+- script/cibuild
+env:
+  global:
+  - secure: EkfjkRuAasRSvjuGC+3vMCw6NdAr2qkqasFQhd5bbfxtKBkbNZoXk3yXvEY+Kzo3Jg4p5IOMW/JIgmDTCXAa/7vxwzAgXOeOlEEbCIAXlTNm07LtNmj2NyHbiDMw5HvaQmZH3TJrqXVTHcPtbzrwzMo+N9YAqTi2p/9fAVq9Xaw=
+  - secure: GurHWDNZzfDLoX8xNYVMl01Llt7N4ZgcVcBb3C0UEIXhGn2ImOuRZbANH8HR2RbhqqW1CpYHixZf/sBJVRcbrYCXf+jBWFtvGS07s09LnIAeWwgicSBujIdFrOPQFCzSCOyrP+hAed+uhf+3vD4UfW1OIp64CtY08i3l40Huarg=
+  - secure: fTrxnKacc0Yfy/ZJFb2GfB6LfDk1E3gMEZoFD/KjQoZP60+BvJN0ihocTJyXXd//69oiEIpPzfZMnmwUPMH378rZGnmDaleHT2UJlDKtHyAMx1owXv7Al9z34nu9kszXQKxsY5H3nMmEPbBkANNW+WeFTPkJngGR7hl9N4IOB68=
+notifications:
+  slack:
+    secure: OvmFNpN8ZYxWx6A4oO7a6mx4S9GHYwdAis38V/Fj/ZxyeYAtreES/zu8nvB7odGmYU3NwEMKY3F9+hurh1VVMNcGQgrDyBxNHYCAc6Hq8u9cNogyYgrzC3RrAsCZS1xYmEQbjvYlzGi8502I5Xrd5hoWgwH1ztL8b00Anui49qk=

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 
 # Rackspace Cloud Orchestration API documentation
 
+[![Build Status](https://travis-ci.org/rackerlabs/docs-cloud-orchestration.svg?branch=master)](https://travis-ci.org/rackerlabs/docs-cloud-orchestration)
+
+
 ## Resources
 
 This github repository contains the source files for the following Rackspace Cloud Orchestration API documentation:

--- a/rst/devguide/_deconst.json
+++ b/rst/devguide/_deconst.json
@@ -1,0 +1,3 @@
+{
+  "contentIDBase": "https://github.com/rackerlabs/docs-cloud-orchestration/"
+}

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Used by Travis to submit content to Nexus production
+
+set -euo pipefail
+
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then
+  echo "Submitting content to production."
+  export CONTENT_STORE_URL=https://developer.rackspace.com:9000/
+  export CONTENT_STORE_APIKEY=${PROD1}${PROD2}${PROD3}
+else
+  echo "Not submitting ${TRAVIS_BRANCH} anywhere."
+fi
+
+cd rst/devguide
+deconst-preparer-sphinx


### PR DESCRIPTION
Configure this repository's Travis build. Once merged, all content committed to the master branch of this repository will be submitted to [developer.rackspace.com](https://developer.rackspace.com/).

Note that the content won't be *routed* and accessible until we submit a follow-on pull request to [the control repository](https://github.com/rackerlabs/nexus-control).
