### PR TITLE
Comment out today specification

### DIFF
--- a/api-docs/conf.py
+++ b/api-docs/conf.py
@@ -82,7 +82,7 @@ language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-today = 'December 8, 2015'
+#today = ' '
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
 


### PR DESCRIPTION
Sphinx version 1.3.2 provides default value for 'today". No need to specify value in conf.py